### PR TITLE
Fix wrong config about gicpConstraint

### DIFF
--- a/src/map_builder/iglio_builder.cpp
+++ b/src/map_builder/iglio_builder.cpp
@@ -217,9 +217,9 @@ namespace lio
                 J.block<3, 3>(0, 6) = state.rot * state.rot_ext * Sophus::SO3d::hat(p_lidar);
                 J.block<3, 3>(0, 9) = -state.rot;
             }
-            Eigen::Matrix3d robust_information_matrix = params_.plane2plane_gain * (rho[1] * omiga + 2.0 * rho[2] * omiga * error * error.transpose() * omiga);
+            Eigen::Matrix3d robust_information_matrix = params_.point2plane_gain * (rho[1] * omiga + 2.0 * rho[2] * omiga * error * error.transpose() * omiga);
             shared_state.H += (J.transpose() * robust_information_matrix * J);
-            shared_state.b += (params_.plane2plane_gain * rho[1] * J.transpose() * omiga * error);
+            shared_state.b += (params_.point2plane_gain * rho[1] * J.transpose() * omiga * error);
         }
 
         if (gicp_cache_.size() < 1)


### PR DESCRIPTION
I compared the code of iG-LIO and found that in IGLIOBuilder:: gicpConstraint, the params _. plane2plane_gain should be params _. point2plane_gain. However, the source code did not utilize point2plane_gain, making it an invalid configuration