### PR TITLE
Fix wrong IGLIOBuilder::fastlioConstraint

### DIFF
--- a/src/map_builder/iglio_builder.cpp
+++ b/src/map_builder/iglio_builder.cpp
@@ -160,8 +160,8 @@ namespace lio
                 J.block<1, 3>(0, 6) = C;
                 J.block<1, 3>(0, 9) = D;
             }
-            shared_state.H += J.transpose() * params_.plane2plane_gain * J;
-            shared_state.b += J.transpose() * params_.plane2plane_gain * error;
+            shared_state.H += J.transpose() * params_.point2plane_gain * J;
+            shared_state.b += J.transpose() * params_.point2plane_gain * error;
         }
 
         if (effect_feat_num < 1)


### PR DESCRIPTION
I compared the code of iG LIO and found that in IGLIOBuilder:: fastlioConstraint, the params _. plane2plane_gain should be params _. point2plane_gain. However, the source code did not utilize point2plane_gain, making it an invalid configuration